### PR TITLE
modify the db/migrate

### DIFF
--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,1 +1,1 @@
-Rails.applocation.config.i18n.default_locale = :ja
+Rails.application.config.i18n.default_locale = :ja

--- a/db/migrate/20190717030931_create_tasks.rb
+++ b/db/migrate/20190717030931_create_tasks.rb
@@ -3,7 +3,6 @@ class CreateTasks < ActiveRecord::Migration[5.2]
     create_table :tasks do |t|
       t.string :name
       t.text :contents
-      t.date :start
       t.date :dl
       t.string :type
       t.integer :prior

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,38 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_07_17_030931) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "tasks", force: :cascade do |t|
+    t.string "name"
+    t.text "contents"
+    t.date "dl"
+    t.string "type"
+    t.integer "prior"
+    t.integer "prog"
+    t.integer "qty"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "pass"
+    t.string "mail"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end


### PR DESCRIPTION
## 処理概要
・db/migrate ****create_tasks.rbの中のstartカラムがデフォルトで作成されるcreated_atと重複してしまっていたため削除した。
・config/initializers/locale.rb内のスペルミスの修正